### PR TITLE
Fix navigation bar bug that causes unexpected behaviour

### DIFF
--- a/TimeLog.md
+++ b/TimeLog.md
@@ -1,34 +1,33 @@
 | Date       | Adshayan | Rishan | Preyansh | Neel | Soumil | Sathursan | Task
-|------------|----------|--------|-------|------|--------| -----------| ------
-| 05/20/2023 | 1        | 0      |0|1|1|1| Brain Storm Meeting
-| 05/21/2023 | 0        | 1      |1|0|0|0| Brain Storm Meeting 2
-| 05/22/2023 | 1        | 1      |1|1|1|1| Feasiblity Research
-| 05/25/2023 | 2.5      | 0      |0|0|0|0| Project Proposal Document Set up + Part 1 of Document
-| 05/26/2023 | 1        | 1      |1|1|1|1|1 Meeting to work on Presentation and flush out original idea
-| 05/30/2023 | 1        | 1      |1|1|1|1| Project Meeting to Pivot Idea to default project
-| 06/01/2023 | 2.5      | 0      |0|0|0|0| Redid Part 1 of Document to support new project idea (default project)
-| 06/01/2023 | 1.5      | 4      |4|4|4|4| Worked on completion of Proposal Document for new project (default project)
-| 06/02/2023 | 2        | 2      |2|2|2|2| Reviewed eachothers work on report, made edits and finalized submission
-| 06/12/2023 | 1        | 1      |1|1|1|1| Brainstorming design plan and architectural structures for project
-| 06/12/2023 | 0        | 1      |0|0|0|0| Update existing mock-ups and create more mock-ups for specific components and screens
-| 06/12/2023 | 0        | 1.5    |0|0|0|0| Create a base file strcture tree outline based on identified subsystems, components, and screens
-| 06/12/2023 | 2        | 0      |0|0|0|0| Set up Android project and Firebase for authentication
-| 06/12/2023 | 2        | 0      |0|0|0|0| Created signup, login, and logout functionality
-| 06/19/2023 | 4.5      | 0      |0|0|0|0| Integrated offline speech to text functionality
-| 06/19/2023 | 0        | 5      |0|0|0|0| Scaffold Home Mode MVVM architecture, add Dagger Hilt, and create Button UI components
-| 06/20/2023 | 2        | 2      |2|2|2|2| App Structure, MVVM Architecture, and Repository Structure Meeting
-| 06/20/2023 | 3        | 0      |0|0|0|0| Refactor SignIn Screen to support MVVM architecture using Jetpack Compose
-| 06/20/2023 | 0        | 2      |0|0|0|0| Add Navigation Host to handle all navigation
-| 06/20/2023 | 1        | 0.5    |0|0|0|0| Address comments to SignIn view CR
-| 06/20/2023 | 0        | 0      |3|0|0|0| Designed high-fidelity mockups in Figma for the Auth Screens, Home Mode, and Farm Mode screens
-| 06/23/2023 | 0        | 0      |3|0|0|0| Finished high-fidelity mockups in Figma for the Market, and Charity Mode
-| 06/23/2023 | 0        | 4      |0|0|0|0| Add navigation bar, app navigator, connect signin to the home page on login, and add a snackbar for messages
-| 06/24/2023 | 4        | 0      |0|0|0|0| Created SignUp view,viewmodel and model with FireBase integration, linked signin and sign up pages 
-| 06/24/2023 |0|0|2|0|0|0| Create Floating Action Button UI component
-| 06/24/2023 |0|0|0|0|0|5| Worked on speech navigation utilty and refactoring to MVVM architecture style
+|------------|----------|--------|-------|------|--------|-----------| ------
+| 05/20/2023 | 1        | 0      |0|1|1| 1         | Brain Storm Meeting
+| 05/21/2023 | 0        | 1      |1|0|0| 0         | Brain Storm Meeting 2
+| 05/22/2023 | 1        | 1      |1|1|1| 1         | Feasiblity Research
+| 05/25/2023 | 2.5      | 0      |0|0|0| 0         | Project Proposal Document Set up + Part 1 of Document
+| 05/26/2023 | 1        | 1      |1|1|1| 1         |1 Meeting to work on Presentation and flush out original idea
+| 05/30/2023 | 1        | 1      |1|1|1| 1         | Project Meeting to Pivot Idea to default project
+| 06/01/2023 | 2.5      | 0      |0|0|0| 0         | Redid Part 1 of Document to support new project idea (default project)
+| 06/01/2023 | 1.5      | 4      |4|4|4| 4         | Worked on completion of Proposal Document for new project (default project)
+| 06/02/2023 | 2        | 2      |2|2|2| 2         | Reviewed eachothers work on report, made edits and finalized submission
+| 06/12/2023 | 1        | 1      |1|1|1| 1         | Brainstorming design plan and architectural structures for project
+| 06/12/2023 | 0        | 1      |0|0|0| 0         | Update existing mock-ups and create more mock-ups for specific components and screens
+| 06/12/2023 | 0        | 1.5    |0|0|0| 0         | Create a base file strcture tree outline based on identified subsystems, components, and screens
+| 06/12/2023 | 2        | 0      |0|0|0| 0         | Set up Android project and Firebase for authentication
+| 06/12/2023 | 2        | 0      |0|0|0| 0         | Created signup, login, and logout functionality
+| 06/19/2023 | 4.5      | 0      |0|0|0| 0         | Integrated offline speech to text functionality
+| 06/19/2023 | 0        | 5      |0|0|0| 0         | Scaffold Home Mode MVVM architecture, add Dagger Hilt, and create Button UI components
+| 06/20/2023 | 2        | 2      |2|2|2| 2         | App Structure, MVVM Architecture, and Repository Structure Meeting
+| 06/20/2023 | 3        | 0      |0|0|0| 0         | Refactor SignIn Screen to support MVVM architecture using Jetpack Compose
+| 06/20/2023 | 0        | 2      |0|0|0| 0         | Add Navigation Host to handle all navigation
+| 06/20/2023 | 1        | 0.5    |0|0|0| 0         | Address comments to SignIn view CR
+| 06/20/2023 | 0        | 0      |3|0|0| 0         | Designed high-fidelity mockups in Figma for the Auth Screens, Home Mode, and Farm Mode screens
+| 06/23/2023 | 0        | 0      |3|0|0| 0         | Finished high-fidelity mockups in Figma for the Market, and Charity Mode
+| 06/23/2023 | 0        | 4      |0|0|0| 0         | Add navigation bar, app navigator, connect signin to the home page on login, and add a snackbar for messages
+| 06/24/2023 | 4        | 0      |0|0|0| 0         | Created SignUp view,viewmodel and model with FireBase integration, linked signin and sign up pages 
+| 06/24/2023 |0| 0      |2|0|0| 0         | Create Floating Action Button UI component
+| 06/24/2023 |0| 0      |0|0|0| 5         | Worked on speech navigation utilty and refactoring to MVVM architecture style
+| 06/24/2023 |0| 0.5     |0|0|0| 0         | Fixed a navigation bar bug that caused unexpected initial behaviour
 | 06/26/2023 |1|1|1|1|1|1| Meeting for demo presentation, synced up to determine next steps  
-
-
 
 
 

--- a/app/src/main/java/com/example/farmeraid/uicomponents/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/farmeraid/uicomponents/BottomNavigationBar.kt
@@ -44,7 +44,8 @@ fun BottomNavigationBar(appNavigator: AppNavigator) {
             navigateToRoute = NavRoute.Farm,
         ),
     )
-    val notShownScreens: List<String> = listOf(
+    val notShownScreens: List<String?> = listOf(
+        null,
         NavRoute.SignIn.route,
         NavRoute.SignUp.route
     )


### PR DESCRIPTION
Fix a navigation bar bug where on initial load of the app, the navigation bar pops up before it re-hides for the login page. This was caused by the fact that initially the app is associated with a null screen. In our navigation bar, we tell it to only not show on Login and Signup screens, so on a null screen it will still show the navbar.