### PR TITLE
Create view quota page and refactor quota/market classes

### DIFF
--- a/TimeLog.md
+++ b/TimeLog.md
@@ -1,5 +1,5 @@
 | Date       | Adshayan | Rishan | Preyansh | Neel | Soumil | Sathursan | Task                                                                                                                                                    |
-| ---------- | -------- | ------ | -------- | ---- | ------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------- | -------- | ------ |----------|------|--------| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 05/20/2023 | 1        | 0      | 0        | 1    | 1      | 1         | Brain Storm Meeting                                                                                                                                     |
 | 05/21/2023 | 0        | 1      | 1        | 0    | 0      | 0         | Brain Storm Meeting 2                                                                                                                                   |
 | 05/22/2023 | 1        | 1      | 1        | 1    | 1      | 1         | Feasiblity Research                                                                                                                                     |
@@ -46,4 +46,5 @@
 | 07/01/2023 | 2        | 0      | 0        | 0    | 0      | 0         | Database Design using Firebase to support App functionality                                                                                             |
 | 07/03/2023 | 0        | 3      | 0        | 0    | 0      | 0         | Improved progress bar and made it more modular                                                                                                          |
 | 07/03/2023 | 3        | 3      | 3        | 3    | 3      | 3         | Database design review + sync for next steps  
-| 07/04/2023 | 3        | 0      | 0        | 0   | 0      | 0          | Script to seed and design firebase database using proposed schema design
+| 07/04/2023 | 3        | 0      | 0        | 0    | 0      | 0         | Script to seed and design firebase database using proposed schema design
+| 07/04/2023 | 0        | 4      | 0        | 0    | 0      | 0         | Create view quota page and refactor quota/market classes

--- a/app/src/main/java/com/example/farmeraid/data/MarketRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/MarketRepository.kt
@@ -1,23 +1,70 @@
 package com.example.farmeraid.data
 
+import android.util.Log
 import com.example.farmeraid.data.model.MarketModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
-class MarketRepository {
+class MarketRepository(
+    private val quotasRepository: QuotasRepository
+) {
     private val markets: MutableList<MarketModel.Market> = mutableListOf(
-        MarketModel.Market("St. Jacob's"),
-        MarketModel.Market("St. Lawrence"),
-        MarketModel.Market("Kensington Market"),
-        MarketModel.Market("St. Catherines Market"),
-        MarketModel.Market("Test Market"),
+        MarketModel.Market(id = "1", name = "St. Jacob's", quotaId = "1"),
+        MarketModel.Market(id = "2", name = "St. Lawrence", quotaId = "2"),
+        MarketModel.Market(id = "3",name = "Kensington Market", quotaId = "3"),
+        MarketModel.Market(id = "4",name = "St. Catherines Market", quotaId = "4"),
+        MarketModel.Market(id = "5", name = "Test Market", quotaId = "5"),
     )
 
     fun getMarkets(): Flow<List<MarketModel.Market>> {
         return flow {
             emit(markets)
         }.flowOn(Dispatchers.IO)
+    }
+
+    fun getMarketsWithQuota() : Flow<List<MarketModel.MarketWithQuota>> {
+        return flow {
+            emit(
+                markets.mapNotNull { market ->
+                    quotasRepository.getQuota(market.quotaId)
+                        ?.let { quota ->
+                            MarketModel.MarketWithQuota(
+                                id = market.id,
+                                name = market.name,
+                                quota = quota,
+                            )
+                        }
+                }
+            )
+        }
+    }
+
+    fun getMarket(id: String) : MarketModel.Market? {
+        return markets.firstOrNull { it.id == id }
+    }
+
+    fun getMarketWithQuota(id : String) : MarketModel.MarketWithQuota? {
+        return markets.firstOrNull { it.id == id }
+            ?.let { market ->
+                quotasRepository.getQuota(market.quotaId)
+                    ?.let { quota ->
+                        MarketModel.MarketWithQuota(
+                            id = market.id,
+                            name = market.name,
+                            quota = quota,
+                        )
+                    }
+            }
+    }
+
+    fun updateMarketQuota(marketId : String, quotaId : String) {
+        val marketIndex : Int = markets.indexOfFirst { it.id == marketId }
+        if (marketIndex >= 0) {
+            markets[marketIndex] = markets[marketIndex].copy(quotaId = quotaId)
+        } else {
+            Log.e("MarketRepository", "Market with id $marketId does not exist")
+        }
     }
 }

--- a/app/src/main/java/com/example/farmeraid/data/QuotasRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/QuotasRepository.kt
@@ -17,12 +17,14 @@ class QuotasRepository {
     )
 
     data class Quota(
-        val marketName : String,
+        val id: String,
         val produceQuotaList : List<ProduceQuota>,
     )
 
+    private var currentId : String = "5"
+
     private val quotasList: MutableList<Quota> = mutableListOf(Quota(
-        marketName = "St. Jacob's",
+        id = "1",
         produceQuotaList = listOf(
             ProduceQuota(
                 produceName = "Apple",
@@ -42,7 +44,7 @@ class QuotasRepository {
             ),
         )
     ), Quota(
-        marketName = "St. Lawrence",
+        id = "2",
         produceQuotaList = listOf(
             ProduceQuota(
                 produceName = "Strawberry",
@@ -54,7 +56,7 @@ class QuotasRepository {
             ),
         )
     ), Quota(
-        marketName = "Kensington Market",
+        id = "3",
         produceQuotaList = listOf(
             ProduceQuota(
                 produceName = "Apple",
@@ -70,7 +72,7 @@ class QuotasRepository {
             ),
         )
     ), Quota(
-        marketName = "St. Catherines Market",
+        id = "4",
         produceQuotaList = listOf(
             ProduceQuota(
                 produceName = "Banana",
@@ -90,23 +92,24 @@ class QuotasRepository {
         }.flowOn(Dispatchers.IO)
     }
 
-    fun getQuota(market : MarketModel.Market): Quota? {
-        return quotasList.firstOrNull { quota -> quota.marketName == market.name }
+    fun getQuota(id : String): Quota? {
+        return quotasList.firstOrNull { quota -> quota.id == id }
     }
 
-    fun addQuota(market : MarketModel.Market, produce : List<ProduceQuota>) {
-        val quotaIndex : Int = quotasList.indexOfFirst { quota -> quota.marketName == market.name }
+    fun addQuota(market : MarketModel.Market, produce : List<ProduceQuota>) : String? {
+        val quotaIndex : Int = quotasList.indexOfFirst { quota -> quota.id == market.quotaId }
 
-        if (quotaIndex >= 0) {
-            quotasList[quotaIndex] = Quota(
-                marketName = market.name,
-                produceQuotaList = produce,
-            )
+        return if (quotaIndex >= 0) {
+            quotasList[quotaIndex] = quotasList[quotaIndex].copy(produceQuotaList = produce)
+            null
         } else {
             quotasList.add(Quota(
-                marketName = market.name,
+                id = currentId,
                 produceQuotaList = produce,
             ))
+            val tempId = currentId
+            currentId = (currentId.toInt() + 1).toString()
+            tempId
         }
     }
 }

--- a/app/src/main/java/com/example/farmeraid/data/model/MarketModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/MarketModel.kt
@@ -1,8 +1,20 @@
 package com.example.farmeraid.data.model
 
+import com.example.farmeraid.data.QuotasRepository
+
 class MarketModel {
     data class Market(
+        val id : String,
         val name: String,
+        val quotaId : String,
+    ) {
+        override fun toString(): String = name
+    }
+
+    data class MarketWithQuota(
+        val id : String,
+        val name : String,
+        val quota : QuotasRepository.Quota,
     ) {
         override fun toString(): String = name
     }

--- a/app/src/main/java/com/example/farmeraid/data/module/RepositoryModule.kt
+++ b/app/src/main/java/com/example/farmeraid/data/module/RepositoryModule.kt
@@ -24,7 +24,7 @@ object RepositoryModule {
     @Provides
     fun provideInventoryRepository(userRepository: UserRepository) : InventoryRepository {
         return InventoryRepository(
-            userRepository=userRepository
+            userRepository = userRepository
         )
     }
 
@@ -42,7 +42,9 @@ object RepositoryModule {
 
     @Singleton
     @Provides
-    fun provideMarketRepository(): MarketRepository {
-        return MarketRepository()
+    fun provideMarketRepository(quotasRepository: QuotasRepository): MarketRepository {
+        return MarketRepository(
+            quotasRepository = quotasRepository
+        )
     }
 }

--- a/app/src/main/java/com/example/farmeraid/home/model/HomeModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/model/HomeModel.kt
@@ -1,6 +1,7 @@
 package com.example.farmeraid.home.model
 import com.example.farmeraid.data.QuotasRepository
 import com.example.farmeraid.data.model.InventoryModel
+import com.example.farmeraid.data.model.MarketModel
 import com.example.farmeraid.navigation.NavRoute
 import com.example.farmeraid.uicomponents.models.UiComponentModel
 
@@ -12,7 +13,8 @@ class HomeModel {
 
     data class HomeViewState(
         val inventoryList: MutableMap<String, Int> = mutableMapOf<String, Int>(),
-        val quotasList: List<QuotasRepository.Quota> = emptyList(),
+        val quotasList: List<MarketModel.MarketWithQuota> = emptyList(),
         val selectedTab: Tab = Tab.Quotas,
+        val isLoading: Boolean = false,
     )
 }

--- a/app/src/main/java/com/example/farmeraid/home/view_quota/ViewQuotaViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/view_quota/ViewQuotaViewModel.kt
@@ -1,0 +1,62 @@
+package com.example.farmeraid.home.view_quota
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.farmeraid.data.MarketRepository
+import com.example.farmeraid.data.QuotasRepository
+import com.example.farmeraid.data.model.MarketModel
+import com.example.farmeraid.home.model.HomeModel
+import com.example.farmeraid.home.view_quota.model.ViewQuotaModel
+import com.example.farmeraid.navigation.AppNavigator
+import com.example.farmeraid.snackbar.SnackbarDelegate
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ViewQuotaViewModel @Inject constructor(
+    marketRepository: MarketRepository,
+    savedStateHandle: SavedStateHandle,
+    private val appNavigator: AppNavigator,
+    private val snackbarDelegate: SnackbarDelegate,
+) : ViewModel() {
+    private val marketId : String? = savedStateHandle["marketId"]
+
+    private val _state = MutableStateFlow(ViewQuotaModel.ViewQuotaViewState())
+    val state: StateFlow<ViewQuotaModel.ViewQuotaViewState>
+        get() = _state
+
+    private val quota : Flow<MarketModel.MarketWithQuota?> = flow {
+        marketId?.let{
+            emit(marketRepository.getMarketWithQuota(marketId))
+        } ?: run {
+            emit(null)
+        }
+    }.flowOn(Dispatchers.IO)
+
+    init {
+        viewModelScope.launch {
+            quota.collect {
+                _state.value = ViewQuotaModel.ViewQuotaViewState(
+                    quota = it
+                )
+            }
+        }
+    }
+
+    fun navigateBack() {
+        appNavigator.navigateBack()
+    }
+
+    fun navigateToEditQuota(id : String) {
+        appNavigator.navigateToEditQuota(id)
+    }
+}

--- a/app/src/main/java/com/example/farmeraid/home/view_quota/model/ViewQuotaModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/view_quota/model/ViewQuotaModel.kt
@@ -1,0 +1,10 @@
+package com.example.farmeraid.home.view_quota.model
+
+import com.example.farmeraid.data.QuotasRepository
+import com.example.farmeraid.data.model.MarketModel
+
+class ViewQuotaModel {
+    data class ViewQuotaViewState(
+        val quota : MarketModel.MarketWithQuota? = null,
+    )
+}

--- a/app/src/main/java/com/example/farmeraid/home/view_quota/views/ViewQuotaScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/home/view_quota/views/ViewQuotaScreenView.kt
@@ -1,0 +1,128 @@
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.farmeraid.home.HomeViewModel
+import com.example.farmeraid.home.view_quota.ViewQuotaViewModel
+import com.example.farmeraid.ui.theme.BlackColour
+import com.example.farmeraid.ui.theme.LightGrayColour
+import com.example.farmeraid.ui.theme.PrimaryColour
+import com.example.farmeraid.ui.theme.WhiteContentColour
+import com.example.farmeraid.uicomponents.ProgressBarView
+import com.example.farmeraid.uicomponents.models.UiComponentModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ViewQuotaScreenView() {
+    val viewModel = hiltViewModel<ViewQuotaViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = "${state.quota?.name ?: "Unknown"} Quota",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { viewModel.navigateBack() }){
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Navigate back",
+                            tint = WhiteContentColour,
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.navigateToEditQuota(state.quota!!.id) }) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = "Edit ${state.quota?.name ?: "Unknown"} Quota",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.smallTopAppBarColors(
+                    containerColor = PrimaryColour,
+                    titleContentColor = WhiteContentColour,
+                    actionIconContentColor = WhiteContentColour,
+                )
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            state.quota?.let {
+                items(it.quota.produceQuotaList) { produceQuota ->
+                    Column(Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                modifier = Modifier
+                                    .width(125.dp),
+                                text = produceQuota.produceName,
+                                fontWeight = FontWeight.Medium,
+                                fontSize = 16.sp,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            // TODO: need to get produce sold amount from market and replace the 1 and 1f
+                            ProgressBarView(
+                                modifier = Modifier.weight(1f).fillMaxSize(),
+                                progressBarUiState = UiComponentModel.ProgressBarUiState(
+                                    text = "1/${produceQuota.produceGoalAmount}",
+                                    fontSize = 14.sp,
+                                    progress = 1f/produceQuota.produceGoalAmount,
+                                    containerColor = PrimaryColour.copy(alpha = 0.2f),
+                                    progressColor = PrimaryColour,
+                                )
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(20.dp))
+                        Divider(modifier = Modifier.height(1.dp), color = LightGrayColour)
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/farmeraid/home/views/HomeScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/home/views/HomeScreenView.kt
@@ -1,8 +1,11 @@
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -10,6 +13,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
@@ -20,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
@@ -96,28 +101,41 @@ fun HomeScreenView() {
             }
         }
     ) { paddingValues ->
-        if (state.selectedTab == Tab.Quotas) {
-            LazyColumn(
-                modifier = Modifier
-                    .padding(paddingValues),
-                verticalArrangement = Arrangement.spacedBy(30.dp),
-                contentPadding = PaddingValues(20.dp),
-            ) {
-                items(state.quotasList) { quota ->
-                    QuotaItem(quota = quota)
-                }
-            }
-        } else {
-            LazyVerticalGrid(
-                modifier = Modifier
-                    .padding(paddingValues),
-                columns = GridCells.Adaptive(150.dp),
-                verticalArrangement = Arrangement.spacedBy(20.dp),
-                horizontalArrangement = Arrangement.spacedBy(20.dp),
-                contentPadding = PaddingValues(20.dp),
-            ) {
-                items(state.inventoryList.toList()) { (produceName, produceAmount) ->
-                    ProduceItem(produceName = produceName, produceAmount = produceAmount)
+        Column(
+            modifier = Modifier.padding(paddingValues).fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top,
+        ) {
+            if (state.isLoading) {
+                CircularProgressIndicator(
+                    color = PrimaryColour,
+                    modifier = Modifier.padding(20.dp).size(25.0.dp),
+                    strokeWidth = 3.0.dp,
+                )
+            } else {
+                if (state.selectedTab == Tab.Quotas) {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(30.dp),
+                        contentPadding = PaddingValues(20.dp),
+                    ) {
+                        items(state.quotasList) { quota ->
+                            QuotaItem(
+                                marketWithQuota = quota,
+                                onClick = { viewModel.navigateToViewQuota(quota.id) }
+                            )
+                        }
+                    }
+                } else {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(150.dp),
+                        verticalArrangement = Arrangement.spacedBy(20.dp),
+                        horizontalArrangement = Arrangement.spacedBy(20.dp),
+                        contentPadding = PaddingValues(20.dp),
+                    ) {
+                        items(state.inventoryList.toList()) { (produceName, produceAmount) ->
+                            ProduceItem(produceName = produceName, produceAmount = produceAmount)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/farmeraid/home/views/QuotaItem.kt
+++ b/app/src/main/java/com/example/farmeraid/home/views/QuotaItem.kt
@@ -1,6 +1,7 @@
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.farmeraid.data.QuotasRepository
+import com.example.farmeraid.data.model.MarketModel
 import com.example.farmeraid.home.model.HomeModel
 import com.example.farmeraid.ui.theme.LightGrayColour
 import com.example.farmeraid.ui.theme.PrimaryColour
@@ -41,13 +43,16 @@ import com.example.farmeraid.uicomponents.models.UiComponentModel
 
 @Composable
 fun QuotaItem(
-    quota : QuotasRepository.Quota,
+    marketWithQuota: MarketModel.MarketWithQuota,
     modifier : Modifier = Modifier,
+    onClick : () -> Unit = {},
 ) {
+    val maxNumOfQuotasShown : Int = 4
+
     Column (
         modifier = modifier
     ) {
-        Text(text = quota.marketName, style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Medium))
+        Text(text = marketWithQuota.name, style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Medium))
         Spacer(modifier = Modifier.height(10.dp))
         Column(
             modifier = Modifier
@@ -59,11 +64,12 @@ fun QuotaItem(
                 .background(
                     Color.White,
                 )
+                .clickable { onClick() }
                 .padding(20.dp)
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            quota.produceQuotaList.forEach { produceQuota ->
+            marketWithQuota.quota.produceQuotaList.take(maxNumOfQuotasShown).forEach { produceQuota ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth(),
@@ -92,6 +98,13 @@ fun QuotaItem(
 
                 }
             }
+            if (marketWithQuota.quota.produceQuotaList.size > maxNumOfQuotasShown) {
+                Text(
+                    text = "+${marketWithQuota.quota.produceQuotaList.size - maxNumOfQuotasShown} more",
+                    fontSize = 12.sp,
+                    color = Color.Gray,
+                )
+            }
         }
     }
 }
@@ -100,17 +113,21 @@ fun QuotaItem(
 @Composable
 fun QuotaItemPreview() {
     QuotaItem(
-        quota = QuotasRepository.Quota(
-            marketName = "Test",
-            produceQuotaList = listOf(
-                QuotasRepository.ProduceQuota(
-                    produceName = "Apples",
-                    produceGoalAmount = 20,
-                ),
-                QuotasRepository.ProduceQuota(
-                    produceName = "Bananas",
-                    produceGoalAmount = 40,
-                ),
+        marketWithQuota = MarketModel.MarketWithQuota(
+            id = "0",
+            name = "Test",
+            quota = QuotasRepository.Quota(
+                id = "0",
+                produceQuotaList = listOf(
+                    QuotasRepository.ProduceQuota(
+                        produceName = "Apples",
+                        produceGoalAmount = 20,
+                    ),
+                    QuotasRepository.ProduceQuota(
+                        produceName = "Bananas",
+                        produceGoalAmount = 40,
+                    ),
+                )
             )
         )
     )

--- a/app/src/main/java/com/example/farmeraid/navigation/AppNavigator.kt
+++ b/app/src/main/java/com/example/farmeraid/navigation/AppNavigator.kt
@@ -16,7 +16,7 @@ class AppNavigator {
     }
 
     fun navigateBack() {
-        _navController?.popBackStack()
+        _navController?.navigateUp()
     }
 
     fun navigateToTransactions() {
@@ -25,5 +25,13 @@ class AppNavigator {
 
     fun navigateToAddQuota() {
         _navController?.navigate(NavRoute.AddEditQuota.route)
+    }
+
+    fun navigateToEditQuota(marketId : String) {
+        _navController?.navigate(NavRoute.AddEditQuota.route + "?marketId=${marketId}")
+    }
+
+    fun navigateToViewQuota(marketId : String) {
+        _navController?.navigate(NavRoute.ViewQuota.route + "/${marketId}")
     }
 }

--- a/app/src/main/java/com/example/farmeraid/navigation/NavRoute.kt
+++ b/app/src/main/java/com/example/farmeraid/navigation/NavRoute.kt
@@ -11,4 +11,6 @@ sealed class NavRoute(val route: String) {
 
     object Transactions : NavRoute("transactions_route")
     object AddEditQuota : NavRoute("add_edit_quota_route")
+
+    object ViewQuota : NavRoute("view_quota_route")
 }

--- a/app/src/main/java/com/example/farmeraid/navigation/RootNavigationHost.kt
+++ b/app/src/main/java/com/example/farmeraid/navigation/RootNavigationHost.kt
@@ -5,6 +5,7 @@ import BottomNavigationBar
 import FarmScreenView
 import HomeScreenView
 import TransactionsView
+import ViewQuotaScreenView
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,8 +17,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.example.farmeraid.sign_in.views.SignInScreenView
 import com.example.farmeraid.sign_up.views.SignUpScreenView
 import com.example.farmeraid.ui.theme.LightGrayColour
@@ -63,11 +66,20 @@ fun RootNavigationHost(
                 composable(NavRoute.Home.route) {
                     HomeScreenView()
                 }
-                composable(NavRoute.AddEditQuota.route) {
+                composable(
+                    route = NavRoute.AddEditQuota.route + "?marketId={marketId}",
+                    arguments = listOf(navArgument("marketId") { nullable = true })
+                ) {
                     AddEditQuotaScreenView()
                 }
                 composable(NavRoute.Transactions.route) {
                     TransactionsView()
+                }
+                composable(
+                    route = NavRoute.ViewQuota.route + "/{marketId}",
+                    arguments = listOf(navArgument("marketId") { type = NavType.StringType})
+                ) {
+                    ViewQuotaScreenView()
                 }
             }
         }

--- a/app/src/main/java/com/example/farmeraid/uicomponents/ProgressBarView.kt
+++ b/app/src/main/java/com/example/farmeraid/uicomponents/ProgressBarView.kt
@@ -68,7 +68,7 @@ fun ProgressBarView(
                 }
             }
             .background(progressBarUiState.containerColor)
-            .padding(5.dp),
+            .padding(2.5.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/app/src/main/java/com/example/farmeraid/uicomponents/SearchableExpandedDropdownMenuView.kt
+++ b/app/src/main/java/com/example/farmeraid/uicomponents/SearchableExpandedDropdownMenuView.kt
@@ -139,7 +139,8 @@ fun <T> SearchableExpandedDropDownMenuView(
                 ) {
                     if (expanded) Icon(
                         imageVector = openedIcon,
-                        contentDescription = null
+                        contentDescription = null,
+                        tint = PrimaryColour,
                     ) else Icon(
                         imageVector = closedIcon,
                         contentDescription = null


### PR DESCRIPTION
This PR does the following:
- Refactors quota and market classes to fit new db schema
- Create view quota page
- Modify add/edit quota page to automatically populate fields with quota associated with edit quota on navigation
- Restrict home screen view quota list to show the first 4 produces

**Demo**

<video src="https://github.com/adshayanB/ECE452/assets/36520027/93b2fedd-168a-4884-9c1d-f4cb8fb50825"/>

