### PR TITLE
Add response class for repository results

### DIFF
--- a/app/src/main/java/com/example/farmeraid/data/model/ResponseModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/ResponseModel.kt
@@ -3,12 +3,15 @@ package com.example.farmeraid.data.model
 import com.example.farmeraid.sign_in.model.SignInModel
 
 class ResponseModel {
-    sealed class FAResponse {
+    sealed class FAResponse(val error : String? = null) {
         object Success : FAResponse()
-        data class Error(val error: String) : FAResponse()
+        class Error(error: String) : FAResponse(error = error)
     }
-    sealed class FAResponseWithData<T> {
-        class Success<T>(val data: T): FAResponseWithData<T>()
-        class Error<T>(val error: String): FAResponseWithData<T>()
+    sealed class FAResponseWithData<T>(
+        val data : T? = null,
+        val error : String? = null,
+    ) {
+        class Success<T>(data: T?): FAResponseWithData<T>(data = data)
+        class Error<T>(error: String): FAResponseWithData<T>(error = error)
     }
 }

--- a/app/src/main/java/com/example/farmeraid/data/model/ResponseModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/ResponseModel.kt
@@ -1,0 +1,14 @@
+package com.example.farmeraid.data.model
+
+import com.example.farmeraid.sign_in.model.SignInModel
+
+class ResponseModel {
+    sealed class FAResponse {
+        object Success : FAResponse()
+        data class Error(val error: String) : FAResponse()
+    }
+    sealed class FAResponseWithData<T> {
+        class Success<T>(val data: T): FAResponseWithData<T>()
+        class Error<T>(val error: String): FAResponseWithData<T>()
+    }
+}


### PR DESCRIPTION
We need to standardize our repository classes to ensure we return errors if anything goes wrong during a get or update. This way we can show the error to the user using the snackbar. This PR creates a universal class that allows you to wrap any class with Success and Error subclasses.

Ex.

```
suspend fun harvest(harvestChanges: MutableMap<String, Int> ) : FAResponse<Boolean> {
    ....
    if (works) {
        return FAResponse.Success(true)
    } else {
        return FAResponse.Error("doesn't work")
    }
    ....
}

val test = harvest(...)
test.data?.let {
    Log.d("Nice works" + it)
} ?: run {
    Log.e("test", "error:" + test?.error ?: "Unknown Error")
}
```