### PR TITLE
improved parsing of speech recognition

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+FarmerAid

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\Rishan\.android\avd\Pixel_3a_API_30_x86.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="935AY06TVW" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-06-30T05:17:20.755405800Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-07-06T20:08:39.405938800Z" />
   </component>
 </project>

--- a/app/src/main/java/com/example/farmeraid/farm/FarmViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/farm/FarmViewModel.kt
@@ -119,21 +119,31 @@ class FarmViewModel @Inject constructor(
     private fun parseSpeech(speechResult: String): List<FarmModel.ProduceHarvest>{
 
         speechRes.value = speechResult
+
+
+
         return harvestList.value.map { produce ->
-            var re = Regex("(add)( )*([0-9]+)( )*${produce.produceName.lowercase()}(s|es)?")
-            var matches = re.findAll(speechResult.lowercase())
+            var reAdd = Regex("(add|at)( )*([0-9]+)( )*([a-z]+)(( )*([0-9]+)( )*([a-z]+))*(( )?(and)( )*([0-9]+)( )*([a-z]+)( )*)*")
+            var addMatches = reAdd.findAll(speechResult.lowercase())
             var count = 0
-            matches.forEach { m ->
-                val action = m.groupValues[1]
-                val quantity = m.groupValues[3].toIntOrNull()
-                //need to handle case when digits are less than 9
-                Log.d("Recognize","${action} ${quantity} ${produce.produceName}")
-                if(quantity != null && action != "" && action == "add"){
-                    count += quantity
+            //Get every add phrase in our speech Result
+            addMatches.forEach { addM ->
+                val addCommand:String = addM.value
+                var reAddAmount = Regex("([0-9]+)( )*${produce.produceName.lowercase()}(s|es)?")
+                var amountMatches = reAddAmount.findAll(addCommand)
+                //Get every instance of the current produce being incremented in the add phrase
+                amountMatches.forEach { amountM ->
+                    val quantity = amountM.groupValues[1].toIntOrNull()
+                    if (quantity != null){
+                        count += quantity
+                    }
                 }
+
             }
-            FarmModel.ProduceHarvest(produceName = produce.produceName, produceCount = produce.produceCount + count )
+
+            FarmModel.ProduceHarvest(produceName = produce.produceName, produceCount = produce.produceCount + count)
         }
+
     }
 
     private fun getMicButtonEvent(): UiComponentModel.FabUiEvent {

--- a/app/src/main/java/com/example/farmeraid/speech_recognition/SpeechRecognizer.kt
+++ b/app/src/main/java/com/example/farmeraid/speech_recognition/SpeechRecognizer.kt
@@ -29,6 +29,18 @@ class SpeechRecognizerUtility() {
     private val permission = Manifest.permission.RECORD_AUDIO
     private var activityContext: Context ?= null
 
+    val stringToNum: Map<String,String> = mapOf(
+        "one" to "1",
+        "two" to "2",
+        "three" to "3",
+        "four" to "4",
+        "five" to "5",
+        "six" to "6",
+        "seven" to "7",
+        "eight" to "8",
+        "nine" to "9",
+    )
+
     private val recognizerIntent: Intent by lazy {
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
@@ -55,7 +67,11 @@ class SpeechRecognizerUtility() {
         override fun onEvent(eventType: Int, params: Bundle?) {}
         override fun onResults(results: Bundle?) {
             val res = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
-            speechRecognizerResult.value = res?.get(0) ?: ""
+            var speechResult = res?.get(0)?: ""
+            stringToNum.forEach {pair->
+                speechResult = speechResult.replace(pair.key, pair.value)
+            }
+            speechRecognizerResult.value = speechResult
             startSpeechRecognition()
         }
     }
@@ -99,3 +115,4 @@ class SpeechRecognizerUtility() {
         activityContext = context
     }
 }
+


### PR DESCRIPTION
Made changes to the speech recognizer.
Originally users had to say `add X apples and add Y bananans and add Z oranges` if they wanted to do compound entries.
With this PR users can now say more natural phrases such as:
`add X apples, Y bananas, and Z oranges`
OR
`add X apples and Y oranges and Z bananans`

Also tweaked the result of the speech recognizer so numbers aren't represented in their text equivalent.
Originally if a person said `add 5 apples` the recognizer would translate this to `add five apples`
Through some manually testing it seems as though only numbers 1-9 are really represented as words in the speech recognizer.
This is now fixed so that the actual number is what we get on the speech recognizer's result text.