### PR TITLE
Code generation farms

### DIFF
--- a/TimeLog.md
+++ b/TimeLog.md
@@ -74,5 +74,6 @@
 | 07/18/2023 | 3        | 3   | 3        | 3   | 3     | 3        | Synced and worked on D5 report
 | 07/18/2023 | 1        |  0  | 1        | 0   | 0     | 0        | Investigated user creation to joining/creating farm flow
 | 07/18/2023 | 2        |  0  | 0        | 0   | 0     | 0        | Completed user creation and farm creation flow to allow the creation of a new farm for a new user linking the firestore db
+| 07/18/2023 | 3        |  0  | 0        | 0   | 0     | 0        | Generated code for newly created farm, stored in firestore, updated view to support new dynamic code creation
 
 

--- a/app/src/main/java/com/example/farmeraid/create_farm/FarmCodeViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/create_farm/FarmCodeViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.farmeraid.create_farm.model.FarmCodeModel
 import com.example.farmeraid.create_farm.model.getStartButton
+import com.example.farmeraid.data.FarmRepository
+import com.example.farmeraid.data.TransactionRepository
 import com.example.farmeraid.navigation.AppNavigator
 import com.example.farmeraid.navigation.NavRoute
 import com.example.farmeraid.uicomponents.models.UiComponentModel
@@ -18,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class FarmCodeViewModel @Inject constructor(
     private val appNavigator: AppNavigator,
+    private val farmRepository: FarmRepository,
 ) : ViewModel() {
     private val _state = MutableStateFlow(FarmCodeModel.FarmCodeViewState(
         buttonUiState = getStartButton()
@@ -29,18 +32,25 @@ class FarmCodeViewModel @Inject constructor(
 
     private val buttonUiState: MutableStateFlow<UiComponentModel.ButtonUiState> = MutableStateFlow(_state.value.buttonUiState)
     private val isLoading : MutableStateFlow<Boolean> = MutableStateFlow(_state.value.isLoading)
+    private val code: MutableStateFlow<String> = MutableStateFlow("")
 
     init {
         viewModelScope.launch {
-            combine(buttonUiState, isLoading) {
-                    buttonUiState: UiComponentModel.ButtonUiState, isLoading : Boolean ->
+            combine(buttonUiState, isLoading, code) {
+                    buttonUiState: UiComponentModel.ButtonUiState, isLoading : Boolean, code: String->
                 FarmCodeModel.FarmCodeViewState(
                     buttonUiState = buttonUiState,
                     isLoading = isLoading,
+                    code = code
                 )
             }.collect {
                 _state.value = it
             }
+        }
+    }
+    init{
+        viewModelScope.launch {
+            code.value = farmRepository.getFarmCode().toString()
         }
     }
 

--- a/app/src/main/java/com/example/farmeraid/create_farm/FarmCodeViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/create_farm/FarmCodeViewModel.kt
@@ -57,6 +57,4 @@ class FarmCodeViewModel @Inject constructor(
     fun navigateToHome() {
         appNavigator.navigateToMode(NavRoute.Home)
     }
-
-    // TODO: create a function to get the RNG Farm Code from Firebase
 }

--- a/app/src/main/java/com/example/farmeraid/create_farm/model/CreateFarmModel.kt
+++ b/app/src/main/java/com/example/farmeraid/create_farm/model/CreateFarmModel.kt
@@ -6,7 +6,7 @@ class CreateFarmModel {
     data class CreateFarmViewState(
         val buttonUiState: UiComponentModel.ButtonUiState,
         val farmName: String = "",
-        val location: String = "",
+        val location: String = ""
     )
 }
 

--- a/app/src/main/java/com/example/farmeraid/create_farm/model/FarmCodeModel.kt
+++ b/app/src/main/java/com/example/farmeraid/create_farm/model/FarmCodeModel.kt
@@ -6,6 +6,7 @@ class FarmCodeModel {
     data class FarmCodeViewState(
         val buttonUiState: UiComponentModel.ButtonUiState,
         val isLoading : Boolean = false,
+        val code: String = "",
     )
 }
 

--- a/app/src/main/java/com/example/farmeraid/create_farm/views/FarmCodeScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/create_farm/views/FarmCodeScreenView.kt
@@ -67,8 +67,6 @@ fun FarmCodeScreenView() {
 
                  Spacer(modifier = Modifier.height(10.dp))
 
-                 // TODO: need to get the RNG Farm Code
-//                 Text(text = "Farm Code: 12345", style = TextStyle(fontSize = 18.sp))
                 Text(text = state.code, style = TextStyle(fontSize = 18.sp ))
 
                  Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/example/farmeraid/create_farm/views/FarmCodeScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/create_farm/views/FarmCodeScreenView.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -66,7 +68,8 @@ fun FarmCodeScreenView() {
                  Spacer(modifier = Modifier.height(10.dp))
 
                  // TODO: need to get the RNG Farm Code
-                 Text(text = "Farm Code: 12345", style = TextStyle(fontSize = 18.sp))
+//                 Text(text = "Farm Code: 12345", style = TextStyle(fontSize = 18.sp))
+                Text(text = state.code, style = TextStyle(fontSize = 18.sp ))
 
                  Spacer(modifier = Modifier.height(20.dp))
 

--- a/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
@@ -92,7 +92,6 @@ class FarmRepository(
     }
 
     suspend fun getTransactionIds (): ResponseModel.FAResponseWithData<MutableList<String>> {
-        Log.d("TEST", "called")
         return (userRepository.getFarmId()?.let { id ->
             try {
                 db.collection("farm").document(id)
@@ -107,6 +106,7 @@ class FarmRepository(
             }
         } ?: ResponseModel.FAResponseWithData.Error("User is not part of a farm"))
     }
+
     //Taken from: https://www.techiedelight.com/generate-a-random-alphanumeric-string-in-kotlin/
     fun generateFarmCode(length: Int) : String {
         val charset = "ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz0123456789"

--- a/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
@@ -31,6 +31,7 @@ class FarmRepository(
                         "farmCode" to code
                     )
                 ).await()
+
                 //Set code state
                 farmCode.value = code
 

--- a/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
@@ -107,11 +107,11 @@ class FarmRepository(
             }
         } ?: ResponseModel.FAResponseWithData.Error("User is not part of a farm"))
     }
-    //Taken from: https://stackoverflow.com/questions/46943860/idiomatic-way-to-generate-a-random-alphanumeric-string-in-kotlin
+    //Taken from: https://www.techiedelight.com/generate-a-random-alphanumeric-string-in-kotlin/
     fun generateFarmCode(length: Int) : String {
-        val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        val charset = "ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz0123456789"
         return (1..length)
-            .map { allowedChars.random() }
+            .map { charset.random() }
             .joinToString("")
     }
 

--- a/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
@@ -3,28 +3,36 @@ package com.example.farmeraid.data
 import android.util.Log
 import com.example.farmeraid.data.model.FarmModel
 import com.example.farmeraid.data.model.ResponseModel
+import com.example.farmeraid.data.model.UserModel
 import com.google.android.gms.tasks.Tasks.await
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.tasks.await
+import kotlin.random.Random
 
 class FarmRepository(
+    val farmCode: MutableStateFlow<String> = MutableStateFlow(""),
     private val userRepository: UserRepository
 ) {
     private var db: FirebaseFirestore = FirebaseFirestore.getInstance()
 
     suspend fun createFarm(farmName: String) : ResponseModel.FAResponse {
         return try {
+            val code = generateFarmCode(6)
             userRepository.getUserId()?.let{
                 val docRef = db.collection("farm").add(
                     mapOf (
                         "name" to farmName,
                         "users" to listOf(it),
                         "markets" to emptyList<String>(),
-                        "charities" to emptyList<String>()
+                        "charities" to emptyList<String>(),
+                        "farmCode" to code
                     )
                 ).await()
+                //Set code state
+                farmCode.value = code
 
                 db.collection("inventory").document(docRef.id).set(
                     mapOf("produce" to emptyMap<String,Int>())
@@ -41,6 +49,7 @@ class FarmRepository(
             //Log.e("FarmRepository - createFarm()", e.message?:"Unknown error")
         }
     }
+
 
     suspend fun joinFarm(farmCode: String) : ResponseModel.FAResponse {
         return try {
@@ -96,5 +105,16 @@ class FarmRepository(
                 ResponseModel.FAResponseWithData.Error(e.message ?: "Unknown error while getting transactions")
             }
         } ?: ResponseModel.FAResponseWithData.Error("User is not part of a farm"))
+    }
+    //Taken from: https://stackoverflow.com/questions/46943860/idiomatic-way-to-generate-a-random-alphanumeric-string-in-kotlin
+    fun generateFarmCode(length: Int) : String {
+        val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        return (1..length)
+            .map { allowedChars.random() }
+            .joinToString("")
+    }
+
+    fun getFarmCode(): String? {
+        return farmCode.value
     }
 }

--- a/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
@@ -1,16 +1,11 @@
 package com.example.farmeraid.data
 
 import android.util.Log
-import com.example.farmeraid.data.model.FarmModel
 import com.example.farmeraid.data.model.ResponseModel
-import com.example.farmeraid.data.model.UserModel
-import com.google.android.gms.tasks.Tasks.await
-import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.tasks.await
-import kotlin.random.Random
 
 class FarmRepository(
     val farmCode: MutableStateFlow<String> = MutableStateFlow(""),


### PR DESCRIPTION
PR created a dynamic code for newly created farms, this code is stored in firestore and is unique. This solves the issue brought up by the other team, as the code has over (26x26x10)^6 possible combinations now. 

Updated UI with new farm code: 
![image](https://github.com/adshayanB/ECE452/assets/41243143/48c437cc-83b0-4d3c-88ea-b2b6f3198b93)

Firestore Schema:
![image](https://github.com/adshayanB/ECE452/assets/41243143/41e34647-7a6e-437a-a94f-1acb31f8fcf4)

![image](https://github.com/adshayanB/ECE452/assets/41243143/000814c1-726a-4521-ac44-f59de713d179)
