### PR TITLE
Fix alphabetical ordering for markets, inventory, and quotas directly from the repos

### DIFF
--- a/TimeLog.md
+++ b/TimeLog.md
@@ -77,5 +77,6 @@
 | 07/18/2023 | 3        |  0  | 0        | 0   | 0     | 0        | Generated code for newly created farm, stored in firestore, updated view to support new dynamic code creation
 | 07/19/2023 | 2        |  0  | 0        | 0   | 0     | 0        | Completed the join farm feature, valdiated functionality via Firestore, updated users who joined with a farmID and role
 | 07/19/2023 | 0.75     |  0  | 0        | 0   | 0     | 0        | Returned values in alphabetical order for Markets and Produce
+| 07/21/2023 | 0     |  0  | 0        | 0.5  | 0     | 0        | Fix alphabetical ordering for markets, inventory, and quotas directly from the repos
 
 

--- a/app/src/main/java/com/example/farmeraid/data/InventoryRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/InventoryRepository.kt
@@ -31,7 +31,7 @@ class InventoryRepository(
                     .get()
                     .await()
                     .data?.get("produce")?.let {
-                        FAResponseWithData.Success(it as MutableMap<String, Int>)
+                        FAResponseWithData.Success((it as MutableMap<String, Int>).toSortedMap(String.CASE_INSENSITIVE_ORDER))
                     } ?: FAResponseWithData.Error("Error fetching produce")
             } catch (e : Exception) {
                 Log.e("InventoryRepository", e.message ?: e.stackTraceToString())

--- a/app/src/main/java/com/example/farmeraid/data/MarketRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/MarketRepository.kt
@@ -1,6 +1,5 @@
 package com.example.farmeraid.data
 
-import android.util.Log
 import com.example.farmeraid.data.model.MarketModel
 import com.example.farmeraid.data.model.ResponseModel
 import com.google.firebase.firestore.DocumentSnapshot
@@ -43,6 +42,7 @@ class MarketRepository(
                 .let { marketModelList.add(it) }
         }
 
+        marketModelList.sortBy { it.name.lowercase() }
         return ResponseModel.FAResponseWithData.Success(marketModelList)
     }
 
@@ -81,7 +81,7 @@ class MarketRepository(
 
             }
         }
-        marketModelList.sortBy { it.name }
+        marketModelList.sortBy { it.name.lowercase() }
         return ResponseModel.FAResponseWithData.Success(marketModelList)
     }
 

--- a/app/src/main/java/com/example/farmeraid/farm/FarmViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/farm/FarmViewModel.kt
@@ -87,7 +87,7 @@ class FarmViewModel @Inject constructor(
     init{
         viewModelScope.launch {
                 inventoryRepository.getInventory().collect{ produce ->
-                    produce.data?.toSortedMap()?.let {
+                    produce.data?.let {
                         harvestList.value = it.map {(produceName, _) ->
                             FarmModel.ProduceHarvest(
                                 produceName = produceName,

--- a/app/src/main/java/com/example/farmeraid/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/HomeViewModel.kt
@@ -64,7 +64,7 @@ class HomeViewModel @Inject constructor(
                     } ?: run {
                         snackbarDelegate.showSnackbar(quotas.error ?: "Unknown error")
                     }
-                    inventory.data?.toSortedMap()?.let {
+                    inventory.data?.let {
                         inventoryList.value = it
                     } ?: run {
                         snackbarDelegate.showSnackbar(inventory.error ?: "Unknown error")

--- a/app/src/main/java/com/example/farmeraid/home/add_edit_quota/AddEditQuotaViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/add_edit_quota/AddEditQuotaViewModel.kt
@@ -168,7 +168,7 @@ class AddEditQuotaViewModel @Inject constructor(
             } else if (produceList.any { it.quantityPickerUiState.count == null }) {
                 snackbarDelegate.showSnackbar("There are one or more invalid values")
             } else {
-                val addResult = quotasRepository.addQuota(market, produceList.mapNotNull { row ->
+                val addResult = quotasRepository.addOrUpdateQuota(market, produceList.mapNotNull { row ->
                     row.produce?.let {
                         row.quantityPickerUiState.count?.let{
                             QuotasRepository.ProduceQuota(


### PR DESCRIPTION
Quotas ordering won't be fixed immediately (as if you look at the changes made, we don't order when fetching quota, but rather we order before adding/updating the quota), but just need to submit a quota once and it will become ordered from then onwards. The reason why I have opted for ordering the quota when adding/updating rather than during fetch is because we retrieve quotas in many different ways (standalone, along with market from market repo, etc.), so I thought it'd be best to resolve the issue on the other part of the flow.