### PR TITLE
Changed filter functionality to appear and disappear based on transaction type filter selections

### DIFF
--- a/app/src/main/java/com/example/farmeraid/data/model/FridgeModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/FridgeModel.kt
@@ -1,11 +1,9 @@
 package com.example.farmeraid.data.model
 
-import com.example.farmeraid.data.CharityRepository
-
 class FridgeModel {
     data class Fridge(
         val fridgeName: String,
         val location: String,
-        val items: List<CharityRepository.ProduceFridge>
+        val items: List<CharityModel.ProduceFridge>
     )
 }

--- a/app/src/main/java/com/example/farmeraid/transactions/model/TransactionsModel.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/model/TransactionsModel.kt
@@ -2,6 +2,7 @@ package com.example.farmeraid.transactions.model
 
 import com.example.farmeraid.data.TransactionRepository
 import com.example.farmeraid.data.model.MarketModel
+import java.util.UUID
 
 class TransactionsModel {
 
@@ -11,11 +12,11 @@ class TransactionsModel {
     )
 
     data class Filter(
+        val id: UUID = UUID.randomUUID(),
         val name: String,
         val itemsList: List<String>,
-        val selected: Boolean = false
+        val selectedItem: String?
     )
-    
     
 }
 
@@ -25,18 +26,42 @@ fun getFilters(
 ): List<TransactionsModel.Filter> {
     val transactionsFilter: TransactionsModel.Filter = TransactionsModel.Filter(
         name = "Type",
-        itemsList = listOf("Harvest", "Sell", "Donate"),
+        itemsList = listOf("Harvest", "Sell", "Donate", "All"),
+        selectedItem = "All"
     )
 
     val marketFilter: TransactionsModel.Filter = TransactionsModel.Filter(
-        name = "Markets",
+        name = "Market",
         itemsList = marketItems.map { it.name },
+        selectedItem = null
     )
 
     val produceFilter: TransactionsModel.Filter = TransactionsModel.Filter(
         name = "Produce",
         itemsList = produceItems.map { it.key },
+        selectedItem = null
     )
 
-    return listOf(transactionsFilter, marketFilter, produceFilter)
+    val charityFilter: TransactionsModel.Filter = TransactionsModel.Filter(
+        name = "Charity",
+        itemsList = listOf("St. James", "Southvale", "Manchester"),
+        selectedItem = null
+    )
+
+    return listOf(transactionsFilter, produceFilter, marketFilter, charityFilter)
+}
+
+fun List<TransactionsModel.Filter>.exposeFilters(): List<TransactionsModel.Filter> {
+    // If SELL or ALL are selected in TransactionType filter -> Market filter pops up
+    // If DONATE or ALL are selected in TransactionType filter -> Charity filter pops up
+
+    val type: TransactionsModel.Filter? = this.firstOrNull{ it.name == "Type" }
+    return type?.let {
+        when( type.selectedItem){
+            "Harvest"-> this.filter { it.name != "Market" && it.name != "Charity" }
+            "Sell"-> this.filter { it.name != "Charity" }
+            "Donate"-> this.filter { it.name != "Market" }
+            else-> this
+        }
+    }?:this
 }

--- a/app/src/main/java/com/example/farmeraid/transactions/views/TransactionsView.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/views/TransactionsView.kt
@@ -58,6 +58,7 @@ import com.example.farmeraid.ui.theme.PrimaryColour
 import com.example.farmeraid.ui.theme.WhiteContentColour
 import com.example.farmeraid.uicomponents.TransactionsFilterChip
 import org.intellij.lang.annotations.JdkConstants.HorizontalAlignment
+import java.util.UUID
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -96,6 +97,7 @@ fun TransactionsView() {
                 items(state.filterList) {filterChip ->
                     TransactionsFilterChip(
                         modifier = Modifier.width(75.dp),
+                        onItemSelected = {id: UUID, item: String->viewModel.updateSelectedFilterItem(id, item)},
                         filter = filterChip
                     )
                 }

--- a/app/src/main/java/com/example/farmeraid/uicomponents/TransactionsFilterChip.kt
+++ b/app/src/main/java/com/example/farmeraid/uicomponents/TransactionsFilterChip.kt
@@ -12,36 +12,39 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.farmeraid.transactions.TransactionsViewModel
 import com.example.farmeraid.transactions.model.TransactionsModel
+import com.example.farmeraid.ui.theme.LightGrayColour
 import com.example.farmeraid.ui.theme.PrimaryColour
 import com.example.farmeraid.ui.theme.WhiteContentColour
 import com.example.farmeraid.uicomponents.models.UiComponentModel
+import java.util.UUID
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TransactionsFilterChip(
     filter: TransactionsModel.Filter,
+    onItemSelected: (id: UUID, selectedItem: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     var expanded by remember { mutableStateOf(false) }
-    var selectedText by remember { mutableStateOf(filter.name) }
 
     ExposedDropdownMenuBox(
         expanded = expanded,
         onExpandedChange = {
-            // expanded = !expanded
         }
     ) {
         InputChip(
             label = {
                 Text(
                     modifier = modifier,
-                    text=selectedText,
+                    text = filter.selectedItem ?: filter.name, // if left is null, do right, else do left
                     maxLines=1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -49,20 +52,25 @@ fun TransactionsFilterChip(
             selected = expanded,
             onClick = { expanded = !expanded },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-            modifier = Modifier.menuAnchor()
+            modifier = Modifier.menuAnchor(),
+            border = InputChipDefaults.inputChipBorder(
+                borderColor = filter.selectedItem?.let { PrimaryColour }?: LightGrayColour
+            )
         )
 
         ExposedDropdownMenu(
             expanded = expanded,
-            onDismissRequest = { expanded = false }
+            onDismissRequest = {
+                expanded = false
+            }
         ) {
             filter.itemsList.forEach { item ->
                 DropdownMenuItem(
                     text = { Text(text = item) },
                     onClick = {
-                        selectedText = item
                         expanded = false
                         Toast.makeText(context, item, Toast.LENGTH_SHORT).show()
+                        onItemSelected(filter.id, item)
                     }
                 )
             }


### PR DESCRIPTION
[TransactionFilter PopupPRVid.zip](https://github.com/adshayanB/ECE452/files/12137572/TransactionFilter.PopupPRVid.zip)

Changed filter functionality to appear and disappear based on transaction type filter selections. The borders of different filters are highlight when an item in that filter is selected.

One thing to note as the mouse was not captured in the video, when a filter item is selected in a filter and that filter item later disappears, on the next appearance of that filter the selected item is retained (for example if "Rishan Market" is selected in the Market filter and then the filter disappears because maybe "Harvest" was selected in the Transaction Type filter, when "Sell" is selected to make Market filter appear, "Rishan Market" is still seen as the selected item).