### PR TITLE
Refactor transaction repository to FAResponse class

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended-android:1.5.0-beta02"
 
     implementation "com.github.StephenVinouze:KontinuousSpeechRecognizer:1.1.0"
-    implementation 'com.github.cesarferreira:kotlin-pluralizer:1.0.0'
+    implementation 'com.github.cesarferreira:kotlin-pluralizer:6a70bc0'
 }
 
 kapt {

--- a/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/FarmRepository.kt
@@ -85,22 +85,6 @@ class FarmRepository(
         } ?: ResponseModel.FAResponseWithData.Error("User is not part of a farm"))
     }
 
-    suspend fun getTransactionIds (): ResponseModel.FAResponseWithData<MutableList<String>> {
-        return (userRepository.getFarmId()?.let { id ->
-            try {
-                db.collection("farm").document(id)
-                    .get()
-                    .await()
-                    .data?.get("transactions")?.let {
-                        ResponseModel.FAResponseWithData.Success(it as MutableList<String>)
-                    } ?: ResponseModel.FAResponseWithData.Error("Error fetching transactions")
-            } catch (e : Exception) {
-                Log.e("InventoryRepository", e.message ?: e.stackTraceToString())
-                ResponseModel.FAResponseWithData.Error(e.message ?: "Unknown error while getting transactions")
-            }
-        } ?: ResponseModel.FAResponseWithData.Error("User is not part of a farm"))
-    }
-
     //Get list of charities
     suspend fun getCharityIds (): ResponseModel.FAResponseWithData<MutableList<String>> {
         Log.d("getCharityIds", "called")

--- a/app/src/main/java/com/example/farmeraid/data/TransactionRepository.kt
+++ b/app/src/main/java/com/example/farmeraid/data/TransactionRepository.kt
@@ -1,15 +1,12 @@
 package com.example.farmeraid.data
 
 import com.example.farmeraid.data.model.InventoryModel
-import com.example.farmeraid.data.model.TransactionsModel
+import com.example.farmeraid.data.model.ResponseModel
+import com.example.farmeraid.data.model.TransactionModel
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.QuerySnapshot
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.tasks.await
 
 class TransactionRepository(
@@ -17,57 +14,77 @@ class TransactionRepository(
 ) {
     private var db: FirebaseFirestore = FirebaseFirestore.getInstance()
 
-    suspend fun addTransaction(transaction: TransactionsModel.Transaction) {
-        val transactionMap = hashMapOf(
-            "count" to transaction.produce.produceAmount,
-            "destination" to transaction.location,
-            "pricePerProduce" to transaction.pricePerProduce, //To do: determine if u want to have a price for transactions, or not
-            "produce" to transaction.produce.produceName,
-            "timestamp" to FieldValue.serverTimestamp(),
-            "type" to transaction.transactionType,
-        )
-
-        val createTransactionRef = db.collection("transaction").document()
-        createTransactionRef.set(transactionMap).await()
-
-        //Update FarmList
-        userRepository.getFarmId()
-            ?.let { db.collection("farm").document(it).update("transactions", FieldValue.arrayUnion(createTransactionRef.id)).await() }
-    }
-
-    suspend fun getRecentTransactions(transactionType: TransactionsModel.TransactionType, limit: Int): Flow<List<TransactionsModel.Transaction>> {
-        val farmID = userRepository.getFarmId()
-
-        val items: QuerySnapshot = if (transactionType == TransactionsModel.TransactionType.ALL){
-                db.collection("transactions").whereEqualTo("farmID", farmID).orderBy("timestamp", Query.Direction.DESCENDING).limit(limit.toLong()).get().await()
-            } else {
-                db.collection("transactions").whereEqualTo("farmID", farmID).whereEqualTo("type", transactionType.stringValue).orderBy("timestamp", Query.Direction.DESCENDING).limit(limit.toLong()).get().await()
-            }
-
-        return flow {
-            emit(
-                items.documents.mapNotNull { transaction ->
-                    transaction.data?.let {
-                        TransactionsModel.Transaction(
-                            transactionId = transaction.id,
-                            transactionType = it["type"] as String,
-                            produce = InventoryModel.Produce(
-                                produceName = it["produce"] as String,
-                                produceAmount = it["count"] as Int,
-                            ),
-                            pricePerProduce = it["pricePerProduce"] as Double,
-                            location = it["destination"] as String,
-                        )
-                    }
-                }
+    suspend fun addTransaction(transaction: TransactionModel.Transaction) : ResponseModel.FAResponse {
+        return userRepository.getFarmId()?.let {farmID ->
+            val transactionMap = hashMapOf(
+                "count" to transaction.produce.produceAmount.toLong(),
+                "destination" to transaction.location,
+                "pricePerProduce" to transaction.pricePerProduce, //To do: determine if u want to have a price for transactions, or not
+                "produce" to transaction.produce.produceName,
+                "timestamp" to FieldValue.serverTimestamp(),
+                "type" to transaction.transactionType,
+                "farmID" to farmID,
             )
-        }.flowOn(Dispatchers.IO)
+
+            val createTransactionRef = db.collection("transaction").document()
+            try {
+                createTransactionRef.set(transactionMap).await()
+                ResponseModel.FAResponse.Success
+            } catch (e: Exception) {
+                ResponseModel.FAResponse.Error(e.message ?: "Unknown error while adding transaction")
+            }
+        } ?: ResponseModel.FAResponse.Error("User does not exist")
     }
 
-    suspend fun deleteTransaction(transactionId: String) {
+    suspend fun getRecentTransactions(transactionType: TransactionModel.TransactionType, limit: Int): ResponseModel.FAResponseWithData<List<TransactionModel.Transaction>> {
+        val items: QuerySnapshot = userRepository.getFarmId()?.let {
+            try {
+                if (transactionType == TransactionModel.TransactionType.ALL){
+                    db.collection("transactions").whereEqualTo("farmID", it).orderBy("timestamp", Query.Direction.DESCENDING).limit(limit.toLong()).get().await()
+                } else {
+                    db.collection("transactions").whereEqualTo("farmID", it).whereEqualTo("type", transactionType.stringValue).orderBy("timestamp", Query.Direction.DESCENDING).limit(limit.toLong()).get().await()
+                }
+            } catch (e: Exception) {
+                return ResponseModel.FAResponseWithData.Error(e.message ?: "Unknown error while fetching transactions")
+            }
+        } ?: run {
+            return ResponseModel.FAResponseWithData.Error("User does not exist")
+        }
+
+        return ResponseModel.FAResponseWithData.Success(
+                    items.documents.mapNotNull { transaction ->
+                        transaction.data?.let {
+                            TransactionModel.Transaction(
+                                transactionId = transaction.id,
+                                transactionType = it["type"] as String,
+                                produce = InventoryModel.Produce(
+                                    produceName = it["produce"] as String,
+                                    produceAmount = (it["count"] as Long).toInt(),
+                                ),
+                                pricePerProduce = it["pricePerProduce"] as Double,
+                                location = it["destination"] as String,
+                            )
+                        }
+                    }
+                )
+    }
+
+    suspend fun deleteTransaction(transactionId: String) : ResponseModel.FAResponse {
         // TODO - Undo the actual transaction before deleting the record
-        db.collection("transactions").document(transactionId).delete().await()
-        userRepository.getFarmId()
-            ?.let { db.collection("farm").document(it).update("transactions", FieldValue.arrayRemove(transactionId)).await() }
+        try {
+            db.collection("transactions").document(transactionId).delete().await()
+        } catch (e: Exception) {
+            return ResponseModel.FAResponse.Error(e.message ?: "Unknown error while deleting transaction")
+        }
+
+        return userRepository.getFarmId()
+            ?.let {
+                try {
+                    db.collection("farm").document(it).update("transactions", FieldValue.arrayRemove(transactionId)).await()
+                    ResponseModel.FAResponse.Success
+                } catch (e: Exception) {
+                    ResponseModel.FAResponse.Error(e.message ?: "Unknown message while updating farm")
+                }
+            } ?: ResponseModel.FAResponse.Error("User does not exist")
     }
 }

--- a/app/src/main/java/com/example/farmeraid/data/model/TransactionModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/TransactionModel.kt
@@ -4,7 +4,7 @@ import com.cesarferreira.pluralize.pluralize
 import java.text.NumberFormat
 import java.util.Locale
 
-class TransactionsModel {
+class TransactionModel {
     enum class TransactionType(val stringValue: String) {
         HARVEST("HARVEST"),
         SELL("SELL"),
@@ -20,17 +20,17 @@ class TransactionsModel {
     )
 }
 
-fun TransactionsModel.Transaction.toMessage() : String{
+fun TransactionModel.Transaction.toMessage() : String{
     return when (transactionType) {
-        TransactionsModel.TransactionType.HARVEST.stringValue -> {
+        TransactionModel.TransactionType.HARVEST.stringValue -> {
             "Harvested ${this.produce.produceAmount} ${this.produce.produceName.pluralize(this.produce.produceAmount)}"
         }
-        TransactionsModel.TransactionType.SELL.stringValue -> {
+        TransactionModel.TransactionType.SELL.stringValue -> {
             "Sold ${this.produce.produceAmount} ${this.produce.produceName.pluralize(this.produce.produceAmount)}" +
                     " for ${NumberFormat.getCurrencyInstance(Locale("en", "US")).format(this.pricePerProduce*this.produce.produceAmount)}" +
                     " to ${this.location}"
         }
-        TransactionsModel.TransactionType.DONATE.stringValue -> {
+        TransactionModel.TransactionType.DONATE.stringValue -> {
             "Donated ${this.produce.produceAmount} ${this.produce.produceName.pluralize(this.produce.produceAmount)}" +
                     " to ${this.location}"
         }

--- a/app/src/main/java/com/example/farmeraid/data/model/TransactionModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/TransactionModel.kt
@@ -6,9 +6,9 @@ import java.util.Locale
 
 class TransactionModel {
     enum class TransactionType(val stringValue: String) {
-        HARVEST("HARVEST"),
-        SELL("SELL"),
-        DONATE("DONATE"),
+        HARVEST("Harvest"),
+        SELL("Sell"),
+        DONATE("Donate"),
         ALL("All");
     }
     data class Transaction(

--- a/app/src/main/java/com/example/farmeraid/data/module/RepositoryModule.kt
+++ b/app/src/main/java/com/example/farmeraid/data/module/RepositoryModule.kt
@@ -41,7 +41,6 @@ object RepositoryModule {
     @Provides
     fun provideTransactionRepository(farmRepository: FarmRepository, userRepository: UserRepository): TransactionRepository {
         return TransactionRepository(
-            farmRepository = farmRepository,
             userRepository = userRepository
         )
     }

--- a/app/src/main/java/com/example/farmeraid/transactions/model/TransactionsModel.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/model/TransactionsModel.kt
@@ -2,12 +2,13 @@ package com.example.farmeraid.transactions.model
 
 import com.example.farmeraid.data.TransactionRepository
 import com.example.farmeraid.data.model.MarketModel
+import com.example.farmeraid.data.model.TransactionModel
 import java.util.UUID
 
 class TransactionsModel {
 
     data class TransactionViewState(
-        val transactionList: List<TransactionRepository.Transaction> = emptyList(),
+        val transactionList: List<TransactionModel.Transaction> = emptyList(),
         val filterList: List<Filter> = emptyList()
     )
 

--- a/app/src/main/java/com/example/farmeraid/transactions/views/TransactionsView.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/views/TransactionsView.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
+import com.example.farmeraid.data.model.toMessage
 import com.example.farmeraid.transactions.TransactionsViewModel
 import com.example.farmeraid.ui.theme.PrimaryColour
 import com.example.farmeraid.ui.theme.WhiteContentColour
@@ -139,7 +140,7 @@ fun TransactionsView() {
                         ){
                             Text(modifier = Modifier
                                 .padding(10.dp, 0.dp, 0.dp, 10.dp),
-                                text = trans.transactionMessage, color = Color.Black,
+                                text = trans.toMessage(), color = Color.Black,
                                 fontSize = 18.sp
                             )
                         }

--- a/firebase_database_schema.py
+++ b/firebase_database_schema.py
@@ -150,8 +150,9 @@ def create_transactions():
         "type": "HARVEST",
         "produce": "Mango",
         "count": 12,
-        "pricePerProduce": 0,
-        "location": "",
+        "pricePerProduce": 0.0,
+        "destination": "",
+        "farmID": FARM_ID,
         "timestamp": firestore.firestore.SERVER_TIMESTAMP,
     })
 
@@ -161,7 +162,8 @@ def create_transactions():
         "produce": "Banana",
         "count": 5,
         "pricePerProduce": 2.57,
-        "location": "Rishan Market",
+        "destination": "Rishan Market",
+        "farmID": FARM_ID,
         "timestamp": firestore.firestore.SERVER_TIMESTAMP,
     })
 
@@ -170,8 +172,9 @@ def create_transactions():
         "type": "DONATE",
         "produce": "Apple",
         "count": 15,
-        "pricePerProduce": 0,
-        "location": "Rishan Charity",
+        "pricePerProduce": 0.0,
+        "destination": "Rishan Charity",
+        "farmID": FARM_ID,
         "timestamp": firestore.firestore.SERVER_TIMESTAMP,
     })
 

--- a/firebase_database_schema.py
+++ b/firebase_database_schema.py
@@ -147,7 +147,7 @@ def create_specfic_quota():
 def create_transactions():
     doc_ref = db.collection("transactions").document("Kycf6h9tSfRjckshgQSz")
     doc_ref.set({
-        "type": "HARVEST",
+        "type": "Harvest",
         "produce": "Mango",
         "count": 12,
         "pricePerProduce": 0.0,
@@ -158,7 +158,7 @@ def create_transactions():
 
     doc_ref = db.collection("transactions").document("o2e2xYKbyfassUSlNbhz")
     doc_ref.set({
-        "type": "SELL",
+        "type": "Sell",
         "produce": "Banana",
         "count": 5,
         "pricePerProduce": 2.57,
@@ -169,7 +169,7 @@ def create_transactions():
 
     doc_ref = db.collection("transactions").document("9JqJJEhwc0TezSoFZXZA")
     doc_ref.set({
-        "type": "DONATE",
+        "type": "Donate",
         "produce": "Apple",
         "count": 15,
         "pricePerProduce": 0.0,


### PR DESCRIPTION
This PR does the following:
- Refactors the transaction repository to now use FAResponse class
- Adds farmID as a property to the transaction schema for use in queries
- Remove transactions list from farm schema since no longer needed with the above change