### PR TITLE
Restrict operations based on user role (and clean up transactions loading)

### DIFF
--- a/app/src/main/java/com/example/farmeraid/data/model/UserModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/UserModel.kt
@@ -4,6 +4,7 @@ class UserModel {
     data class User(
         val email: String,
         val id: String,
-        val farm_id: String
+        val farm_id: String,
+        val admin: Boolean,
     )
 }

--- a/app/src/main/java/com/example/farmeraid/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/HomeViewModel.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val marketRepository: MarketRepository,
     private val inventoryRepository: InventoryRepository,
+    private val userRepository: UserRepository,
     private val appNavigator: AppNavigator,
     private val snackbarDelegate: SnackbarDelegate,
 ) : ViewModel() {
@@ -78,6 +79,10 @@ class HomeViewModel @Inject constructor(
         selectedTab.value = tab;
     }
 
+    fun userIsAdmin() : Boolean {
+        return userRepository.isAdmin()
+    }
+
     fun navigateToAddQuota() {
         appNavigator.navigateToAddQuota()
     }
@@ -90,6 +95,8 @@ class HomeViewModel @Inject constructor(
     }
 
     fun navigateToEditProduce(produceName : String, produceAmount : Int) {
-        appNavigator.navigateToEditProduce(produceName, produceAmount)
+        if (userIsAdmin()) {
+            appNavigator.navigateToEditProduce(produceName, produceAmount)
+        }
     }
 }

--- a/app/src/main/java/com/example/farmeraid/home/view_quota/ViewQuotaViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/home/view_quota/ViewQuotaViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.farmeraid.data.MarketRepository
 import com.example.farmeraid.data.QuotasRepository
+import com.example.farmeraid.data.UserRepository
 import com.example.farmeraid.data.model.MarketModel
 import com.example.farmeraid.data.model.ResponseModel
 import com.example.farmeraid.home.model.HomeModel
@@ -27,6 +28,7 @@ class ViewQuotaViewModel @Inject constructor(
     marketRepository: MarketRepository,
     savedStateHandle: SavedStateHandle,
     private val quotasRepository: QuotasRepository,
+    private val userRepository: UserRepository,
     private val appNavigator: AppNavigator,
     private val snackbarDelegate: SnackbarDelegate,
 ) : ViewModel() {
@@ -84,6 +86,10 @@ class ViewQuotaViewModel @Inject constructor(
                 snackbarDelegate.showSnackbar("No quota id provided")
             }
         }
+    }
+
+    fun userIsAdmin() : Boolean {
+        return userRepository.isAdmin()
     }
 
     fun navigateBack() {

--- a/app/src/main/java/com/example/farmeraid/home/view_quota/views/ViewQuotaScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/home/view_quota/views/ViewQuotaScreenView.kt
@@ -68,19 +68,21 @@ fun ViewQuotaScreenView() {
                     }
                 },
                 actions = {
-                    IconButton(onClick = { viewModel.navigateToEditQuota() }) {
-                        Icon(
-                            imageVector = Icons.Filled.Edit,
-                            contentDescription = "Edit ${state.quota?.name ?: "Unknown"} Quota",
-                            tint = WhiteContentColour,
-                        )
-                    }
-                    IconButton(onClick = { viewModel.confirmDeleteQuota() }) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = "Delete ${state.quota?.name ?: "Unknown"} Quota",
-                            tint = WhiteContentColour,
-                        )
+                    if (viewModel.userIsAdmin()) {
+                        IconButton(onClick = { viewModel.navigateToEditQuota() }) {
+                            Icon(
+                                imageVector = Icons.Filled.Edit,
+                                contentDescription = "Edit ${state.quota?.name ?: "Unknown"} Quota",
+                                tint = WhiteContentColour,
+                            )
+                        }
+                        IconButton(onClick = { viewModel.confirmDeleteQuota() }) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = "Delete ${state.quota?.name ?: "Unknown"} Quota",
+                                tint = WhiteContentColour,
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.smallTopAppBarColors(

--- a/app/src/main/java/com/example/farmeraid/home/views/HomeScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/home/views/HomeScreenView.kt
@@ -55,21 +55,23 @@ fun HomeScreenView() {
 
     Scaffold(
         floatingActionButton = {
-            FloatingActionButtonView(
-                fabUiState = UiComponentModel.FabUiState(
-                    icon = Icons.Filled.Add,
-                    contentDescription = if (state.selectedTab == Tab.Quotas)  "Add Quota" else "Add Produce",
-                ),
-                fabUiEvent = UiComponentModel.FabUiEvent(
-                    onClick = {
-                        if (state.selectedTab == Tab.Quotas) {
-                            viewModel.navigateToAddQuota()
-                        } else {
-                            viewModel.navigateToAddProduce()
+            if (viewModel.userIsAdmin()) {
+                FloatingActionButtonView(
+                    fabUiState = UiComponentModel.FabUiState(
+                        icon = Icons.Filled.Add,
+                        contentDescription = if (state.selectedTab == Tab.Quotas)  "Add Quota" else "Add Produce",
+                    ),
+                    fabUiEvent = UiComponentModel.FabUiEvent(
+                        onClick = {
+                            if (state.selectedTab == Tab.Quotas) {
+                                viewModel.navigateToAddQuota()
+                            } else {
+                                viewModel.navigateToAddProduce()
+                            }
                         }
-                    }
+                    )
                 )
-            )
+            }
         },
         topBar = {
             TabRow(

--- a/app/src/main/java/com/example/farmeraid/market/MarketViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/market/MarketViewModel.kt
@@ -3,6 +3,7 @@ package com.example.farmeraid.market
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.farmeraid.data.MarketRepository
+import com.example.farmeraid.data.UserRepository
 import com.example.farmeraid.data.model.MarketModel
 import com.example.farmeraid.data.model.TransactionModel
 import com.example.farmeraid.market.model.MarketPageModel
@@ -18,6 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MarketViewModel @Inject constructor(
     private val marketRepository: MarketRepository,
+    private val userRepository: UserRepository,
     private val appNavigator: AppNavigator,
     private val snackbarDelegate: SnackbarDelegate,
 ) : ViewModel() {
@@ -57,6 +59,10 @@ class MarketViewModel @Inject constructor(
 
             isLoading.value = false
         }
+    }
+
+    fun userIsAdmin() : Boolean {
+        return userRepository.isAdmin()
     }
 
     fun navigateToSellProduce(marketId: String) {

--- a/app/src/main/java/com/example/farmeraid/market/sell_produce/SellProduceViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/market/sell_produce/SellProduceViewModel.kt
@@ -7,6 +7,7 @@ import com.example.farmeraid.data.InventoryRepository
 import com.example.farmeraid.data.MarketRepository
 import com.example.farmeraid.data.QuotasRepository
 import com.example.farmeraid.data.TransactionRepository
+import com.example.farmeraid.data.UserRepository
 import com.example.farmeraid.data.model.InventoryModel
 import com.example.farmeraid.data.model.MarketModel
 import com.example.farmeraid.data.model.QuotaModel
@@ -30,6 +31,7 @@ class SellProduceViewModel @Inject constructor(
     private val marketRepository: MarketRepository,
     private val quotasRepository: QuotasRepository,
     private val transactionRepository: TransactionRepository,
+    private val userRepository: UserRepository,
     savedStateHandle: SavedStateHandle,
     private val appNavigator: AppNavigator,
     private val snackbarDelegate: SnackbarDelegate,
@@ -201,6 +203,10 @@ class SellProduceViewModel @Inject constructor(
 
     fun getTotalEarnings(): Double {
         return produceSellList.value.sumOf { produceSell -> produceSell.produceTotalPrice }
+    }
+
+    fun userIsAdmin() : Boolean {
+        return userRepository.isAdmin()
     }
 
     fun navigateToTransactions() {

--- a/app/src/main/java/com/example/farmeraid/market/sell_produce/views/SellProduceView.kt
+++ b/app/src/main/java/com/example/farmeraid/market/sell_produce/views/SellProduceView.kt
@@ -76,12 +76,14 @@ fun SellProduceView() {
                     }
                 },
                 actions = {
-                    IconButton(onClick = { viewModel.navigateToEditMarket(state.marketId) }) {
-                        Icon(
-                            imageVector = Icons.Filled.Edit,
-                            contentDescription = "Edit ${state.marketName ?: "Unknown"} Market",
-                            tint = WhiteContentColour,
-                        )
+                    if (viewModel.userIsAdmin()) {
+                        IconButton(onClick = { viewModel.navigateToEditMarket(state.marketId) }) {
+                            Icon(
+                                imageVector = Icons.Filled.Edit,
+                                contentDescription = "Edit ${state.marketName ?: "Unknown"} Market",
+                                tint = WhiteContentColour,
+                            )
+                        }
                     }
                     IconButton(onClick = { viewModel.navigateToTransactions() }) {
                         Icon(

--- a/app/src/main/java/com/example/farmeraid/market/views/MarketScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/market/views/MarketScreenView.kt
@@ -43,17 +43,19 @@ fun MarketScreenView() {
 
     Scaffold(
         floatingActionButton = {
-            FloatingActionButtonView(
-                fabUiState = UiComponentModel.FabUiState(
-                    icon = Icons.Filled.Add,
-                    contentDescription = "Add Market",
-                ),
-                fabUiEvent = UiComponentModel.FabUiEvent(
-                    onClick = {
-                        viewModel.navigateToAddMarket()
-                    }
+            if (viewModel.userIsAdmin()) {
+                FloatingActionButtonView(
+                    fabUiState = UiComponentModel.FabUiState(
+                        icon = Icons.Filled.Add,
+                        contentDescription = "Add Market",
+                    ),
+                    fabUiEvent = UiComponentModel.FabUiEvent(
+                        onClick = {
+                            viewModel.navigateToAddMarket()
+                        }
+                    )
                 )
-            )
+            }
         },
         topBar = {
             CenterAlignedTopAppBar(

--- a/app/src/main/java/com/example/farmeraid/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/TransactionsViewModel.kt
@@ -161,6 +161,10 @@ class TransactionsViewModel @Inject constructor(
         }
     }
 
+    fun userIsAdmin() : Boolean {
+        return userRepository.isAdmin()
+    }
+
     fun navigateBack() {
         appNavigator.navigateBack()
     }

--- a/app/src/main/java/com/example/farmeraid/transactions/views/TransactionsView.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/views/TransactionsView.kt
@@ -98,18 +98,7 @@ fun TransactionsView() {
                 .padding(20.dp, 10.dp, 20.dp, 0.dp),
 
         ){
-            if (state.isLoading) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(
-                        color = PrimaryColour,
-                        modifier = Modifier
-                            .size(48.0.dp)
-                    )
-                }
-            } else {
+            if (state.filterList.isNotEmpty()) {
                 LazyRow(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
@@ -135,6 +124,8 @@ fun TransactionsView() {
                 }
                 Spacer(modifier = Modifier.height(10.dp))
                 Divider()
+            }
+            if (!state.isLoading) {
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                     contentPadding = PaddingValues(0.dp, 20.dp),
@@ -154,7 +145,7 @@ fun TransactionsView() {
                             ){
                                 Row(modifier = Modifier
                                     .fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    horizontalArrangement = if (viewModel.userIsAdmin()) Arrangement.SpaceBetween else Arrangement.Start,
                                 ){
                                     Text(modifier = Modifier.offset(0.dp, (-5).dp),
                                         text = trans.transactionType.stringValue,
@@ -162,7 +153,9 @@ fun TransactionsView() {
                                         color = Color.Black,
                                         fontSize = 25.sp
                                     )
-                                    Icon(Icons.Outlined.Close, contentDescription = "Localized description", modifier = Modifier.clickable { viewModel.showDeleteConfirmation(trans) })
+                                    if (viewModel.userIsAdmin()) {
+                                        Icon(Icons.Outlined.Close, contentDescription = "Localized description", modifier = Modifier.clickable { viewModel.showDeleteConfirmation(trans) })
+                                    }
                                 }
 
                                 Spacer(modifier = Modifier.height(5.dp))
@@ -176,6 +169,17 @@ fun TransactionsView() {
                             }
                         }
                     }
+                }
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        color = PrimaryColour,
+                        modifier = Modifier
+                            .size(48.0.dp)
+                    )
                 }
             }
 

--- a/app/src/main/java/com/example/farmeraid/uicomponents/TransactionsFilterChip.kt
+++ b/app/src/main/java/com/example/farmeraid/uicomponents/TransactionsFilterChip.kt
@@ -87,7 +87,6 @@ fun TransactionsFilterChip(
                         text = { Text(text = item) },
                         onClick = {
                             expanded = false
-                            Toast.makeText(context, item, Toast.LENGTH_SHORT).show()
                             onItemSelected(filter.id, item)
                         }
                     )


### PR DESCRIPTION
This PR adds restrictions to non-admin users so that they can only view produce, quotas, markets, and transactions, and they can harvest, sell, and donate.

Also fixed a minor UI nit for loading in the Transactions view.