### PR TITLE
Remove Pluralize for Transaction Messages

### DIFF
--- a/app/src/main/java/com/example/farmeraid/data/model/TransactionModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/TransactionModel.kt
@@ -39,15 +39,15 @@ class TransactionModel {
 fun TransactionModel.Transaction.toMessage() : String{
     return when (transactionType) {
         TransactionModel.TransactionType.HARVEST -> {
-            "Harvested ${this.produce.produceAmount} ${this.produce.produceName.pluralize(this.produce.produceAmount)}"
+            "Harvested ${this.produce.produceAmount} ${this.produce.produceName}"
         }
         TransactionModel.TransactionType.SELL -> {
-            "Sold ${this.produce.produceAmount} ${this.produce.produceName.pluralize(this.produce.produceAmount)}" +
+            "Sold ${this.produce.produceAmount} ${this.produce.produceName}" +
                     " for ${NumberFormat.getCurrencyInstance(Locale("en", "US")).format(this.pricePerProduce*this.produce.produceAmount)}" +
                     " to ${this.location}"
         }
         TransactionModel.TransactionType.DONATE -> {
-            "Donated ${this.produce.produceAmount} ${this.produce.produceName.pluralize(this.produce.produceAmount)}" +
+            "Donated ${this.produce.produceAmount} ${this.produce.produceName}" +
                     " to ${this.location}"
         }
         else -> {


### PR DESCRIPTION
Remove pluralize for produce name when constructing transaction message as it glitches for some produce names (e.g. Onion) and transforms the name weirdly.