### PR TITLE
Total Earnings For Markets

### DIFF
--- a/app/src/main/java/com/example/farmeraid/charity/views/CharityMapsScreenView.kt
+++ b/app/src/main/java/com/example/farmeraid/charity/views/CharityMapsScreenView.kt
@@ -191,8 +191,4 @@ fun CharityMapsScreenView() {
             }
         }
     }
-
-//    }
-
-
 }

--- a/app/src/main/java/com/example/farmeraid/data/model/MarketModel.kt
+++ b/app/src/main/java/com/example/farmeraid/data/model/MarketModel.kt
@@ -5,6 +5,7 @@ class MarketModel {
         val id : String,
         val name: String,
         val prices: MutableMap<String, Double>,
+        val saleCount: Double,
     ) {
         override fun toString(): String = name
     }
@@ -14,6 +15,7 @@ class MarketModel {
         val name : String,
         val prices: MutableMap<String, Double>,
         val quota : QuotaModel.Quota,
+        val saleCount: Double,
     ) {
         override fun toString(): String = name
     }

--- a/app/src/main/java/com/example/farmeraid/home/views/QuotaItem.kt
+++ b/app/src/main/java/com/example/farmeraid/home/views/QuotaItem.kt
@@ -107,6 +107,7 @@ fun QuotaItemPreview() {
             id = "0",
             name = "Test",
             prices = hashMapOf("Apples" to 20.0, "Bananas" to 30.0),
+            saleCount = 100.0,
             quota = QuotaModel.Quota(
                 id = "0",
                 produceQuotaList = listOf(

--- a/app/src/main/java/com/example/farmeraid/market/sell_produce/SellProduceViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/market/sell_produce/SellProduceViewModel.kt
@@ -159,6 +159,8 @@ class SellProduceViewModel @Inject constructor(
 
             val market: MarketModel.Market = marketRepository.getMarket(marketId!!).data!!
 
+            marketRepository.updateSaleCount(marketId, getTotalEarnings())
+
             quotasRepository.getQuota(market.id, market.name).let { quota ->
                 quota.data?.let { quotaData ->
                     quotasRepository.updateSaleCounts(

--- a/app/src/main/java/com/example/farmeraid/market/views/MarketItem.kt
+++ b/app/src/main/java/com/example/farmeraid/market/views/MarketItem.kt
@@ -43,6 +43,8 @@ fun MarketItem(
     ) {
         Text(text = market.name, style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Medium))
         Spacer(modifier = Modifier.height(10.dp))
+        Text(text = "Total Sales: ${numberFormat.format(market.saleCount)}", style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Normal))
+        Spacer(modifier = Modifier.height(10.dp))
         Column(
             modifier = Modifier
                 .clip(RoundedCornerShape(16.dp))

--- a/app/src/main/java/com/example/farmeraid/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/example/farmeraid/transactions/TransactionsViewModel.kt
@@ -149,6 +149,7 @@ class TransactionsViewModel @Inject constructor(
                                 quota?.let {
                                     quotasRepository.updateSaleCounts(it.id, changeMap.entries.associate {entry -> entry.key to -1*entry.value })
                                 }
+                                marketRepository.updateSaleCount(market.id, -1 * transaction.produce.produceAmount * transaction.pricePerProduce)
                             }
                             TransactionModel.TransactionType.DONATE -> {
                                 inventoryRepository.harvest(changeMap)


### PR DESCRIPTION
This PR does the following:

- Shows total earnings for each market on the page page
- Logic to update the total earnings if a user sells or undo transactions